### PR TITLE
Click markdown table cells to run slash commands

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-    "id": "com.mattermost.plugin-starter-template",
+    "id": "link-action-example",
     "name": "Plugin Starter Template",
     "description": "This plugin serves as a starting point for writing a Mattermost plugin.",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-starter-template",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -2651,28 +2651,6 @@
         }
       }
     },
-    "@emotion/babel-utils": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-utils/-/babel-utils-0.6.10.tgz",
-      "integrity": "sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==",
-      "dev": true,
-      "requires": {
-        "@emotion/hash": "^0.6.6",
-        "@emotion/memoize": "^0.6.6",
-        "@emotion/serialize": "^0.9.1",
-        "convert-source-map": "^1.5.1",
-        "find-root": "^1.1.0",
-        "source-map": "^0.7.2"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        }
-      }
-    },
     "@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -2835,64 +2813,16 @@
         }
       }
     },
-    "@emotion/hash": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.6.6.tgz",
-      "integrity": "sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ==",
-      "dev": true
-    },
-    "@emotion/memoize": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.6.tgz",
-      "integrity": "sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==",
-      "dev": true
-    },
-    "@emotion/serialize": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.9.1.tgz",
-      "integrity": "sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==",
-      "dev": true,
-      "requires": {
-        "@emotion/hash": "^0.6.6",
-        "@emotion/memoize": "^0.6.6",
-        "@emotion/unitless": "^0.6.7",
-        "@emotion/utils": "^0.8.2"
-      }
-    },
     "@emotion/sheet": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
       "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
       "dev": true
     },
-    "@emotion/stylis": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.7.1.tgz",
-      "integrity": "sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ==",
-      "dev": true
-    },
-    "@emotion/unitless": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.6.7.tgz",
-      "integrity": "sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg==",
-      "dev": true
-    },
-    "@emotion/utils": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
-      "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==",
-      "dev": true
-    },
     "@emotion/weak-memoize": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
-      "dev": true
-    },
-    "@icons/material": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
       "dev": true
     },
     "@istanbuljs/load-nyc-config": {
@@ -3822,25 +3752,6 @@
         }
       }
     },
-    "@popmotion/easing": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@popmotion/easing/-/easing-1.0.2.tgz",
-      "integrity": "sha512-IkdW0TNmRnWTeWI7aGQIVDbKXPWHVEYdGgd5ZR4SH/Ty/61p63jCjrPxX1XrR7IGkl08bjhJROStD7j+RKgoIw==",
-      "dev": true
-    },
-    "@popmotion/popcorn": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@popmotion/popcorn/-/popcorn-0.4.4.tgz",
-      "integrity": "sha512-jYO/8319fKoNLMlY4ZJPiPu8Ea8occYwRZhxpaNn/kZsK4QG2E7XFlXZMJBsTWDw7I1i0uaqyC4zn1nwEezLzg==",
-      "dev": true,
-      "requires": {
-        "@popmotion/easing": "^1.0.1",
-        "framesync": "^4.0.1",
-        "hey-listen": "^1.0.8",
-        "style-value-types": "^3.1.7",
-        "tslib": "^1.10.0"
-      }
-    },
     "@react-native-community/netinfo": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-4.7.0.tgz",
@@ -4473,12 +4384,6 @@
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
     },
-    "add-px-to-style": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/add-px-to-style/-/add-px-to-style-1.0.0.tgz",
-      "integrity": "sha1-0ME1RB+oAUqBN5BFMQlvZ/KPJjo=",
-      "dev": true
-    },
     "airbnb-prop-types": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.15.0.tgz",
@@ -4862,12 +4767,6 @@
         }
       }
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
-    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
@@ -4953,11 +4852,6 @@
       "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
       "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
       "dev": true
-    },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -5329,26 +5223,6 @@
         "object.assign": "^4.1.0"
       }
     },
-    "babel-plugin-emotion": {
-      "version": "9.2.11",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz",
-      "integrity": "sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@emotion/babel-utils": "^0.6.4",
-        "@emotion/hash": "^0.6.2",
-        "@emotion/memoize": "^0.6.1",
-        "@emotion/stylis": "^0.7.0",
-        "babel-plugin-macros": "^2.0.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "find-root": "^1.1.0",
-        "mkdirp": "^0.5.1",
-        "source-map": "^0.5.7",
-        "touch": "^2.0.1"
-      }
-    },
     "babel-plugin-istanbul": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
@@ -5539,9 +5413,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-          "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
         },
         "regenerator-runtime": {
           "version": "0.11.1",
@@ -5674,21 +5548,6 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
-    },
-    "bootstrap": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
-      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
-      "dev": true
-    },
-    "bootstrap-colorpicker": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/bootstrap-colorpicker/-/bootstrap-colorpicker-2.5.2.tgz",
-      "integrity": "sha512-krzBno9AMUwI2+IDwMvjnpqpa2f8womW0CCKmEcxGzVkolCFrt22jjMjzx1NZqB8C1DUdNgZP4LfyCsgpHRiYA==",
-      "dev": true,
-      "requires": {
-        "jquery": ">=1.10"
-      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -6005,52 +5864,6 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
-    "chart.js": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.8.0.tgz",
-      "integrity": "sha512-Di3wUL4BFvqI5FB5K26aQ+hvWh8wnP9A3DWGvXHVkO13D3DSnaSsdZx29cXlEsYKVkn1E2az+ZYFS4t0zi8x0w==",
-      "dev": true,
-      "requires": {
-        "chartjs-color": "^2.1.0",
-        "moment": "^2.10.2"
-      }
-    },
-    "chartjs-color": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
-      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
-      "dev": true,
-      "requires": {
-        "chartjs-color-string": "^0.6.0",
-        "color-convert": "^1.9.3"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        }
-      }
-    },
-    "chartjs-color-string": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
-      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
-      "dev": true,
-      "requires": {
-        "color-name": "^1.0.0"
-      }
-    },
     "cheerio": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
@@ -6170,12 +5983,6 @@
         }
       }
     },
-    "classnames": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
-      "dev": true
-    },
     "cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -6280,12 +6087,6 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
-    "compass-mixins": {
-      "version": "0.12.10",
-      "resolved": "https://registry.npmjs.org/compass-mixins/-/compass-mixins-0.12.10.tgz",
-      "integrity": "sha1-zZ8V+CnE6WDMQ7sibwSbKL65nUE=",
-      "dev": true
-    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -6337,12 +6138,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
       "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-      "dev": true
-    },
-    "cookiejar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
       "dev": true
     },
     "copy-concurrently": {
@@ -6455,21 +6250,6 @@
         }
       }
     },
-    "create-emotion": {
-      "version": "9.2.12",
-      "resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-9.2.12.tgz",
-      "integrity": "sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==",
-      "dev": true,
-      "requires": {
-        "@emotion/hash": "^0.6.2",
-        "@emotion/memoize": "^0.6.1",
-        "@emotion/stylis": "^0.7.0",
-        "@emotion/unitless": "^0.6.2",
-        "csstype": "^2.5.2",
-        "stylis": "^3.5.0",
-        "stylis-rule-sheet": "^0.0.10"
-      }
-    },
     "create-hash": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -6495,27 +6275,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "create-react-context": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
-      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-      "dev": true,
-      "requires": {
-        "gud": "^1.0.0",
-        "warning": "^4.0.3"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
       }
     },
     "cross-spawn": {
@@ -6650,12 +6409,6 @@
         }
       }
     },
-    "css-vars-ponyfill": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/css-vars-ponyfill/-/css-vars-ponyfill-2.0.2.tgz",
-      "integrity": "sha512-x2q/VmPwQFxNOXdQcR+VOJ6GjaLDVo1aqJhZp2ommTwBa7Vlg5ulBcxknIOxvU/mkTOPhsafaXQE1oRnLJjErw==",
-      "dev": true
-    },
     "css-what": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
@@ -6766,12 +6519,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
-    },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
     "deep-is": {
@@ -6909,26 +6656,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "dom-css": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/dom-css/-/dom-css-2.1.0.tgz",
-      "integrity": "sha1-/bwtWgFdCj4YcuEUcrvQ57nmogI=",
-      "dev": true,
-      "requires": {
-        "add-px-to-style": "1.0.0",
-        "prefix-style": "2.0.1",
-        "to-camel-case": "1.0.0"
-      }
-    },
-    "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2"
-      }
-    },
     "dom-serializer": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
@@ -6952,12 +6679,6 @@
           "dev": true
         }
       }
-    },
-    "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
-      "dev": true
     },
     "domain-browser": {
       "version": "1.2.0",
@@ -7070,22 +6791,22 @@
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
-    "emotion": {
-      "version": "9.2.12",
-      "resolved": "https://registry.npmjs.org/emotion/-/emotion-9.2.12.tgz",
-      "integrity": "sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-emotion": "^9.2.11",
-        "create-emotion": "^9.2.12"
-      }
-    },
     "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
       }
     },
     "end-of-stream": {
@@ -7883,12 +7604,6 @@
         }
       }
     },
-    "eslint-plugin-header": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.0.0.tgz",
-      "integrity": "sha512-OIu2ciVW8jK4Ove4JHm1I7X0C98PZuLCyCsoUhAm2HpyGS+zr34qLM6iV06unnDvssvvEh5BkOfaLRF+N7cGoQ==",
-      "dev": true
-    },
     "eslint-plugin-import": {
       "version": "2.22.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
@@ -8178,12 +7893,6 @@
         "strip-eof": "^1.0.0"
       }
     },
-    "exif2css": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/exif2css/-/exif2css-1.3.0.tgz",
-      "integrity": "sha512-RBjZaFcNumDz3bZiZGsR3Kg2jouyLuRnUPox7yE24WcvK8IhVdShAwSQHEqupGC0/DYDZsiunk+sv8CLmu4Lqg==",
-      "dev": true
-    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -8434,18 +8143,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "fast-safe-stringify": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
-      "dev": true
-    },
-    "fastclick": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/fastclick/-/fastclick-1.0.6.tgz",
-      "integrity": "sha1-FhYlsnsaWAZAWTa9qaLBkm0Gvmo=",
-      "dev": true
-    },
     "fb-watchman": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
@@ -8453,38 +8150,6 @@
       "dev": true,
       "requires": {
         "bser": "^2.0.0"
-      }
-    },
-    "fbemitter": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz",
-      "integrity": "sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=",
-      "dev": true,
-      "requires": {
-        "fbjs": "^0.8.4"
-      }
-    },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "dev": true,
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-          "dev": true
-        }
       }
     },
     "figgy-pudding": {
@@ -8625,12 +8290,6 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
-    "flexsearch": {
-      "version": "0.6.23",
-      "resolved": "https://registry.npmjs.org/flexsearch/-/flexsearch-0.6.23.tgz",
-      "integrity": "sha512-WZWmAymAMpEX1un8gayWu3dgRk0Tmtm7QnZ1stPbzfihXyGQLneE3aEGxKIdZjHyh2WWUSPkBLjU/kkUy8rBXw==",
-      "dev": true
-    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -8640,22 +8299,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
-    },
-    "flux": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-3.1.3.tgz",
-      "integrity": "sha1-0jvtUVp5oi2TOrU6tK2hnQWy8Io=",
-      "dev": true,
-      "requires": {
-        "fbemitter": "^2.0.0",
-        "fbjs": "^0.8.0"
-      }
-    },
-    "font-awesome": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=",
-      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -8680,12 +8323,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "formidable": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==",
-      "dev": true
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -8693,16 +8330,6 @@
       "dev": true,
       "requires": {
         "map-cache": "^0.2.2"
-      }
-    },
-    "framesync": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-4.0.4.tgz",
-      "integrity": "sha512-mdP0WvVHe0/qA62KG2LFUAOiWLng5GLpscRlwzBxu2VXOp6B8hNs5C5XlFigsMgrfDrr2YbqTsgdWZTc4RXRMQ==",
-      "dev": true,
-      "requires": {
-        "hey-listen": "^1.0.8",
-        "tslib": "^1.10.0"
       }
     },
     "from2": {
@@ -9004,16 +8631,6 @@
         }
       }
     },
-    "global": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
-      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "dev": true,
-      "requires": {
-        "min-document": "^2.19.0",
-        "process": "^0.11.10"
-      }
-    },
     "global-modules": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
@@ -9077,12 +8694,6 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true,
       "optional": true
-    },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==",
-      "dev": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -9228,32 +8839,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "hey-listen": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
-      "dev": true
-    },
-    "highlight.js": {
-      "version": "9.15.8",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.8.tgz",
-      "integrity": "sha512-RrapkKQWwE+wKdF73VsOa2RQdIoO3mxwJ4P8mhbI6KYJUraUHRKM5w5zQQKXNk0xNL4UVRdulV9SBJcmzJNzVA==",
-      "dev": true
-    },
-    "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
-      }
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -9312,19 +8897,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "html-to-react": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.3.4.tgz",
-      "integrity": "sha512-/tWDdb/8Koi/QEP5YUY1653PcDpBnnMblXRhotnTuhFDjI1Fc6Wzox5d4sw73Xk5rM2OdM5np4AYjT/US/Wj7Q==",
-      "dev": true,
-      "requires": {
-        "domhandler": "^2.4.2",
-        "escape-string-regexp": "^1.0.5",
-        "htmlparser2": "^3.10.0",
-        "lodash.camelcase": "^4.3.0",
-        "ramda": "^0.26"
-      }
-    },
     "htmlparser2": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
@@ -9379,6 +8951,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -9416,12 +8989,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-      "dev": true
-    },
-    "immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
       "dev": true
     },
     "import-fresh": {
@@ -9543,12 +9110,6 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
-    "inobounce": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/inobounce/-/inobounce-0.2.0.tgz",
-      "integrity": "sha512-eJt1MQEqLKanAFEE5DkSF36d9uyg8kLb/R6ysEF7udJOM5JZXidkhhGv6WoWbEcVdyRqZfYMjv6XbSIz7tD4CQ==",
-      "dev": true
-    },
     "internal-slot": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.2.tgz",
@@ -9619,12 +9180,6 @@
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
-    "intl": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/intl/-/intl-1.2.5.tgz",
-      "integrity": "sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94=",
-      "dev": true
-    },
     "intl-format-cache": {
       "version": "2.2.9",
       "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-2.2.9.tgz",
@@ -9689,12 +9244,6 @@
           }
         }
       }
-    },
-    "is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-      "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -10331,12 +9880,6 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
-    },
-    "jasny-bootstrap": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/jasny-bootstrap/-/jasny-bootstrap-3.1.3.tgz",
-      "integrity": "sha1-sHKmgdUMZJdiyVQ8emCT2bqi+Hs=",
-      "dev": true
     },
     "jest": {
       "version": "26.1.0",
@@ -12744,12 +12287,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
-      "dev": true
-    },
     "js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
@@ -12890,35 +12427,6 @@
         "object.assign": "^4.1.0"
       }
     },
-    "katex": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.10.2.tgz",
-      "integrity": "sha512-cQOmyIRoMloCoSIOZ1+gEwsksdJZ1EW4SWm3QzxSza/QsnZr6D4U1V9S4q+B/OLm2OQ8TCBecQ8MaIfnScI7cw==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.19.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true
-        }
-      }
-    },
-    "key-mirror": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/key-mirror/-/key-mirror-1.0.1.tgz",
-      "integrity": "sha1-ChMtXIqCo6T8199zL/lRDQSrNms=",
-      "dev": true
-    },
-    "keycode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
-      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=",
-      "dev": true
-    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -12960,15 +12468,6 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
-      }
-    },
-    "lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
-      "dev": true,
-      "requires": {
-        "immediate": "~3.0.5"
       }
     },
     "lines-and-columns": {
@@ -13019,33 +12518,6 @@
         "json5": "^1.0.1"
       }
     },
-    "localforage": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.3.tgz",
-      "integrity": "sha512-1TulyYfc4udS7ECSBT2vwJksWbkwwTX8BzeUIiq8Y07Riy7bDAAnxDaPU/tWyOVmQAcWJIEIFP9lPfBGqVoPgQ==",
-      "dev": true,
-      "requires": {
-        "lie": "3.1.1"
-      }
-    },
-    "localforage-observable": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/localforage-observable/-/localforage-observable-2.0.0.tgz",
-      "integrity": "sha512-QZco9bV2XIJ7WU5Z+zJ7NT0xxN9J8BgHbJhdsA2k6OJGfR4jCBRoA/QiwQmKJhqX6TAFAjLN4sO3QEzNldVw0A==",
-      "dev": true,
-      "requires": {
-        "localforage": "^1.5.0",
-        "zen-observable": "^0.2.1"
-      },
-      "dependencies": {
-        "zen-observable": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.2.1.tgz",
-          "integrity": "sha1-xHZ2pkEyuEdaYapJ5RR1W1uWY/M=",
-          "dev": true
-        }
-      }
-    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -13062,15 +12534,9 @@
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash-es": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.14.tgz",
-      "integrity": "sha512-7zchRrGa8UZXjD/4ivUWP1867jDkhzTG2c/uj739utSd7O/pFFdxspCemIFKEEjErbcqRzn8nKnGsi7mvTgRPA=="
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.escape": {
       "version": "4.0.1",
@@ -13171,23 +12637,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "mark.js": {
-      "version": "8.11.1",
-      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
-      "integrity": "sha1-GA8fnr74sOY45BZq1S24eb6y/8U=",
-      "dev": true
-    },
-    "marked": {
-      "version": "github:mattermost/marked#3a9d0a5bd6d735df1a716ab50f73d58a1d865bdb",
-      "from": "github:mattermost/marked#3a9d0a5bd6d735df1a716ab50f73d58a1d865bdb",
-      "dev": true
-    },
-    "material-colors": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
-      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
-      "dev": true
-    },
     "mattermost-redux": {
       "version": "5.27.0",
       "resolved": "https://registry.npmjs.org/mattermost-redux/-/mattermost-redux-5.27.0.tgz",
@@ -13225,220 +12674,6 @@
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
           }
-        },
-        "moment-timezone": {
-          "version": "0.5.28",
-          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
-          "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
-          "requires": {
-            "moment": ">= 2.9.0"
-          }
-        },
-        "redux-persist": {
-          "version": "4.9.1",
-          "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-4.9.1.tgz",
-          "integrity": "sha512-XoOmfPyo9GEU/WLH9FgB47dNIN9l5ArjHes4o7vUWx9nxZoPxnVodhuHdyc4Ot+fMkdj3L2LTqSHhwrkr0QFUg==",
-          "requires": {
-            "json-stringify-safe": "^5.0.1",
-            "lodash": "^4.17.4",
-            "lodash-es": "^4.17.4"
-          }
-        }
-      }
-    },
-    "mattermost-webapp": {
-      "version": "github:mattermost/mattermost-webapp#23f5f93d9f12a7e2b5623e5cee6814366abd9a0f",
-      "from": "github:mattermost/mattermost-webapp#23f5f93d9f12a7e2b5623e5cee6814366abd9a0f",
-      "dev": true,
-      "requires": {
-        "bootstrap": "3.4.1",
-        "bootstrap-colorpicker": "2.5.2",
-        "chart.js": "2.8.0",
-        "compass-mixins": "0.12.10",
-        "core-js": "3.1.4",
-        "css-vars-ponyfill": "2.0.2",
-        "emoji-regex": "8.0.0",
-        "exif2css": "1.3.0",
-        "fastclick": "1.0.6",
-        "flexsearch": "0.6.23",
-        "flux": "3.1.3",
-        "font-awesome": "4.7.0",
-        "highlight.js": "9.15.8",
-        "hoist-non-react-statics": "3.3.0",
-        "html-to-react": "1.3.4",
-        "inobounce": "0.2.0",
-        "intl": "1.2.5",
-        "jasny-bootstrap": "3.1.3",
-        "jquery": "3.4.1",
-        "katex": "0.10.2",
-        "key-mirror": "1.0.1",
-        "localforage": "1.7.3",
-        "localforage-observable": "2.0.0",
-        "mark.js": "8.11.1",
-        "marked": "github:mattermost/marked#3a9d0a5bd6d735df1a716ab50f73d58a1d865bdb",
-        "mattermost-redux": "github:mattermost/mattermost-redux#40e5bd5a18daa919c62a06b360aa27f2e6ed3e13",
-        "moment-timezone": "0.5.26",
-        "pdfjs-dist": "2.0.489",
-        "perfect-scrollbar": "0.8.1",
-        "popmotion": "8.7.0",
-        "popper.js": "1.15.0",
-        "prop-types": "15.7.2",
-        "react": "16.8.6",
-        "react-addons-pure-render-mixin": "15.6.2",
-        "react-bootstrap": "github:mattermost/react-bootstrap#c6957962364e0818a51bbfd13e89919903b422d6",
-        "react-color": "2.17.3",
-        "react-contextmenu": "2.11.0",
-        "react-custom-scrollbars": "4.2.1",
-        "react-day-picker": "7.3.0",
-        "react-dom": "16.8.6",
-        "react-hot-loader": "4.12.8",
-        "react-intl": "2.9.0",
-        "react-overlays": "1.2.0",
-        "react-redux": "5.1.1",
-        "react-router-dom": "5.0.1",
-        "react-select": "2.4.4",
-        "react-transition-group": "4.2.1",
-        "react-virtualized-auto-sizer": "1.0.2",
-        "react-window": "github:mattermost/react-window#4c694b7633a2527a42c4952235719fefa3accb80",
-        "rebound": "0.1.0",
-        "redux": "4.0.4",
-        "redux-batched-actions": "0.4.1",
-        "redux-persist": "4.10.2",
-        "regenerator-runtime": "^0.13.3",
-        "reselect": "4.0.0",
-        "superagent": "5.1.0",
-        "xregexp": "4.2.4",
-        "zen-observable": "0.8.14"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.1.4.tgz",
-          "integrity": "sha512-YNZN8lt82XIMLnLirj9MhKDFZHalwzzrL9YLt6eb0T5D0EDl4IQ90IGkua8mHbnxNrkj1d8hbdizMc0Qmg1WnQ==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.0.tgz",
-          "integrity": "sha512-WXieX3G/8side6VIqx44ablyULoGruSde5PNTxoUyo5CeyAMX6nVWUd0rgist/EuX655cjhUhTo1Fo3tRYqbcA==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "hoist-non-react-statics": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
-          "dev": true,
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        },
-        "jquery": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-          "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
-          "dev": true
-        },
-        "mattermost-redux": {
-          "version": "github:mattermost/mattermost-redux#40e5bd5a18daa919c62a06b360aa27f2e6ed3e13",
-          "from": "github:mattermost/mattermost-redux#40e5bd5a18daa919c62a06b360aa27f2e6ed3e13",
-          "dev": true,
-          "requires": {
-            "deep-equal": "1.0.1",
-            "eslint-plugin-header": "3.0.0",
-            "form-data": "2.5.0",
-            "gfycat-sdk": "1.4.18",
-            "harmony-reflect": "1.6.1",
-            "isomorphic-fetch": "2.2.1",
-            "mime-db": "1.40.0",
-            "moment-timezone": "0.5.26",
-            "redux": "4.0.4",
-            "redux-action-buffer": "1.2.0",
-            "redux-batched-actions": "0.4.1",
-            "redux-offline": "git+https://github.com/enahum/redux-offline.git#885024de96b6ec73650c340c8928066585c413df",
-            "redux-persist": "4.9.1",
-            "redux-thunk": "2.3.0",
-            "reselect": "4.0.0",
-            "serialize-error": "2.1.0",
-            "shallow-equals": "1.0.0"
-          },
-          "dependencies": {
-            "redux-persist": {
-              "version": "4.9.1",
-              "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-4.9.1.tgz",
-              "integrity": "sha512-XoOmfPyo9GEU/WLH9FgB47dNIN9l5ArjHes4o7vUWx9nxZoPxnVodhuHdyc4Ot+fMkdj3L2LTqSHhwrkr0QFUg==",
-              "dev": true,
-              "requires": {
-                "json-stringify-safe": "^5.0.1",
-                "lodash": "^4.17.4",
-                "lodash-es": "^4.17.4"
-              }
-            }
-          }
-        },
-        "prop-types": {
-          "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "object-assign": "^4.1.1",
-            "react-is": "^16.8.1"
-          }
-        },
-        "react": {
-          "version": "16.8.6",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-          "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.13.6"
-          }
-        },
-        "react-redux": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.1.1.tgz",
-          "integrity": "sha512-LE7Ned+cv5qe7tMV5BPYkGQ5Lpg8gzgItK07c67yHvJ8t0iaD9kPFPAli/mYkiyJYrs2pJgExR2ZgsGqlrOApg==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.1.2",
-            "hoist-non-react-statics": "^3.1.0",
-            "invariant": "^2.2.4",
-            "loose-envify": "^1.1.0",
-            "prop-types": "^15.6.1",
-            "react-is": "^16.6.0",
-            "react-lifecycles-compat": "^3.0.0"
-          }
-        },
-        "redux": {
-          "version": "4.0.4",
-          "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
-          "integrity": "sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.4.0",
-            "symbol-observable": "^1.2.0"
-          }
-        },
-        "serialize-error": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-          "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go=",
-          "dev": true
         }
       }
     },
@@ -13452,12 +12687,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
-    },
-    "memoize-one": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==",
-      "dev": true
     },
     "memory-fs": {
       "version": "0.2.0",
@@ -13576,12 +12805,6 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
-    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -13621,12 +12844,6 @@
         }
       }
     },
-    "mime": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
-      "dev": true
-    },
     "mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
@@ -13645,26 +12862,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
-    },
-    "min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true,
-      "requires": {
-        "dom-walk": "^0.1.0"
-      }
-    },
-    "mini-create-react-context": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
-      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.4.0",
-        "gud": "^1.0.0",
-        "tiny-warning": "^1.0.2"
-      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -13742,15 +12939,14 @@
       }
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "moment-timezone": {
-      "version": "0.5.26",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.26.tgz",
-      "integrity": "sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==",
-      "dev": true,
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
+      "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
       "requires": {
         "moment": ">= 2.9.0"
       }
@@ -13848,12 +13044,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
-    },
-    "node-ensure": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
-      "integrity": "sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc=",
       "dev": true
     },
     "node-fetch": {
@@ -14104,15 +13294,6 @@
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
-      }
-    },
-    "nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1"
       }
     },
     "normalize-package-data": {
@@ -14644,23 +13825,6 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
-    "path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        }
-      }
-    },
     "path-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -14690,22 +13854,6 @@
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
       }
-    },
-    "pdfjs-dist": {
-      "version": "2.0.489",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.0.489.tgz",
-      "integrity": "sha1-Y+VLKSqGeQpFRpfrRNQ0e4+/rSc=",
-      "dev": true,
-      "requires": {
-        "node-ensure": "^0.0.0",
-        "worker-loader": "^1.1.1"
-      }
-    },
-    "perfect-scrollbar": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/perfect-scrollbar/-/perfect-scrollbar-0.8.1.tgz",
-      "integrity": "sha512-RNC5tX/JMRYR+qVdJTEAWnRxw0Yf9lvbO8lTuAOvgDODkiA8lveTSkvrNMhmaGKEyimJpJl+myb/syVS9YyPuw==",
-      "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
@@ -14757,27 +13905,6 @@
       "requires": {
         "find-up": "^3.0.0"
       }
-    },
-    "popmotion": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-8.7.0.tgz",
-      "integrity": "sha512-RnJMbWN+TEBT0tgG+3WS0O1i9LAq+senXSAcKw+srGviT1c9G+iKUXrp24D2w6Og0mDd61rEfKz3pFrFCdKn5Q==",
-      "dev": true,
-      "requires": {
-        "@popmotion/easing": "^1.0.1",
-        "@popmotion/popcorn": "^0.4.0",
-        "framesync": "^4.0.0",
-        "hey-listen": "^1.0.5",
-        "style-value-types": "^3.1.4",
-        "stylefire": "^4.1.3",
-        "tslib": "^1.9.1"
-      }
-    },
-    "popper.js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA==",
-      "dev": true
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -14871,12 +13998,6 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
-    "prefix-style": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/prefix-style/-/prefix-style-2.0.1.tgz",
-      "integrity": "sha1-ZrupqHDP2jCKXcIOhekSCTLJWgY=",
-      "dev": true
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -14946,15 +14067,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "dev": true,
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -14989,16 +14101,6 @@
         "has": "^1.0.3",
         "object.assign": "^4.1.0",
         "reflect.ownkeys": "^0.2.0"
-      }
-    },
-    "prop-types-extra": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.0.tgz",
-      "integrity": "sha512-QFyuDxvMipmIVKD2TwxLVPzMnO4e5oOf1vr3tJIomL8E7d0lr6phTHd5nkPhFIzTD1idBLLEPeylL9g+rrTzRg==",
-      "dev": true,
-      "requires": {
-        "react-is": "^16.3.2",
-        "warning": "^3.0.0"
       }
     },
     "prr": {
@@ -15112,12 +14214,6 @@
       "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
       "dev": true
     },
-    "ramda": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
-      "dev": true
-    },
     "randexp": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
@@ -15157,167 +14253,6 @@
         "prop-types": "^15.6.2"
       }
     },
-    "react-addons-pure-render-mixin": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/react-addons-pure-render-mixin/-/react-addons-pure-render-mixin-15.6.2.tgz",
-      "integrity": "sha1-a4P0C2s27kBzXL1hJes/E84c3ck=",
-      "dev": true,
-      "requires": {
-        "fbjs": "^0.8.4",
-        "object-assign": "^4.1.0"
-      }
-    },
-    "react-bootstrap": {
-      "version": "github:mattermost/react-bootstrap#c6957962364e0818a51bbfd13e89919903b422d6",
-      "from": "github:mattermost/react-bootstrap#c6957962364e0818a51bbfd13e89919903b422d6",
-      "dev": true,
-      "requires": {
-        "@babel/runtime-corejs2": "^7.0.0",
-        "classnames": "^2.2.5",
-        "dom-helpers": "^3.2.0",
-        "invariant": "^2.2.4",
-        "keycode": "^2.2.0",
-        "prop-types": "^15.6.1",
-        "prop-types-extra": "^1.0.1",
-        "react-overlays": "^0.8.0",
-        "react-prop-types": "^0.4.0",
-        "react-transition-group": "^2.0.0",
-        "uncontrollable": "^5.0.0",
-        "warning": "^3.0.0"
-      },
-      "dependencies": {
-        "react-overlays": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.8.3.tgz",
-          "integrity": "sha512-h6GT3jgy90PgctleP39Yu3eK1v9vaJAW73GOA/UbN9dJ7aAN4BTZD6793eI1D5U+ukMk17qiqN/wl3diK1Z5LA==",
-          "dev": true,
-          "requires": {
-            "classnames": "^2.2.5",
-            "dom-helpers": "^3.2.1",
-            "prop-types": "^15.5.10",
-            "prop-types-extra": "^1.0.1",
-            "react-transition-group": "^2.2.0",
-            "warning": "^3.0.0"
-          }
-        },
-        "react-transition-group": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-          "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        }
-      }
-    },
-    "react-color": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.17.3.tgz",
-      "integrity": "sha512-1dtO8LqAVotPIChlmo6kLtFS1FP89ll8/OiA8EcFRDR+ntcK+0ukJgByuIQHRtzvigf26dV5HklnxDIvhON9VQ==",
-      "dev": true,
-      "requires": {
-        "@icons/material": "^0.2.4",
-        "lodash": "^4.17.11",
-        "material-colors": "^1.2.1",
-        "prop-types": "^15.5.10",
-        "reactcss": "^1.2.0",
-        "tinycolor2": "^1.4.1"
-      }
-    },
-    "react-context-toolbox": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/react-context-toolbox/-/react-context-toolbox-2.0.2.tgz",
-      "integrity": "sha512-tY4j0imkYC3n5ZlYSgFkaw7fmlCp3IoQQ6DxpqeNHzcD0hf+6V+/HeJxviLUZ1Rv1Yn3N3xyO2EhkkZwHn0m1A==",
-      "dev": true
-    },
-    "react-contextmenu": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/react-contextmenu/-/react-contextmenu-2.11.0.tgz",
-      "integrity": "sha512-vT9QV9p/9h1BSIvmajRVG3KsgjuBnISpEQp0F1QYsUPFMe3VOKV2l7IiD8yrNUyXYZKrWMqI0YKsaBwGSRVgJg==",
-      "dev": true,
-      "requires": {
-        "classnames": "^2.2.5",
-        "object-assign": "^4.1.0"
-      }
-    },
-    "react-custom-scrollbars": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/react-custom-scrollbars/-/react-custom-scrollbars-4.2.1.tgz",
-      "integrity": "sha1-gw/ZUCkn6X6KeMIIaBOJmyqLZts=",
-      "dev": true,
-      "requires": {
-        "dom-css": "^2.0.0",
-        "prop-types": "^15.5.10",
-        "raf": "^3.1.0"
-      }
-    },
-    "react-day-picker": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-7.3.0.tgz",
-      "integrity": "sha512-t2kz0Zy4P5U4qwU5YhsBq2QGmypP8L/u+89TSnuD0h4dYKSEDQArFPWfin9gv8erV1ciR1Wzr485TMaYnI7FTw==",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.6.2"
-      }
-    },
-    "react-dom": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
-      }
-    },
-    "react-hot-loader": {
-      "version": "4.12.8",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.8.tgz",
-      "integrity": "sha512-/Df2J3znMHzRzI6CW0dTOIWD2sjkVHxv56XCqujAo9mR+k2PVTiGjUgYBiGPGsix9zQzgCRfOKca93o9Zdj2vQ==",
-      "dev": true,
-      "requires": {
-        "fast-levenshtein": "^2.0.6",
-        "global": "^4.3.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "loader-utils": "^1.1.0",
-        "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "shallowequal": "^1.0.2",
-        "source-map": "^0.7.3"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-          "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
-          "dev": true,
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        },
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        }
-      }
-    },
-    "react-input-autosize": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
-      "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
-      "dev": true,
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
-    },
     "react-intl": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-2.9.0.tgz",
@@ -15346,98 +14281,6 @@
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
-    },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "dev": true
-    },
-    "react-overlays": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-1.2.0.tgz",
-      "integrity": "sha512-i/FCV8wR6aRaI+Kz/dpJhOdyx+ah2tN1RhT9InPrexyC4uzf3N4bNayFTGtUeQVacj57j1Mqh1CwV60/5153Iw==",
-      "dev": true,
-      "requires": {
-        "classnames": "^2.2.6",
-        "dom-helpers": "^3.4.0",
-        "prop-types": "^15.6.2",
-        "prop-types-extra": "^1.1.0",
-        "react-context-toolbox": "^2.0.2",
-        "react-popper": "^1.3.2",
-        "uncontrollable": "^6.0.0",
-        "warning": "^4.0.2"
-      },
-      "dependencies": {
-        "uncontrollable": {
-          "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-6.2.3.tgz",
-          "integrity": "sha512-VgOAoBU2ptCL2bfTG2Mra0I8i1u6Aq84AFonD5tmCAYSfs3hWvr2Rlw0q2ntoxXTHjcQOmZOh3FKaN+UZVyREQ==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.4.5",
-            "invariant": "^2.2.4"
-          }
-        },
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
-    "react-popper": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
-      "integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "create-react-context": "^0.3.0",
-        "deep-equal": "^1.1.1",
-        "popper.js": "^1.14.4",
-        "prop-types": "^15.6.1",
-        "typed-styles": "^0.0.7",
-        "warning": "^4.0.2"
-      },
-      "dependencies": {
-        "deep-equal": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-          "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-          "dev": true,
-          "requires": {
-            "is-arguments": "^1.0.4",
-            "is-date-object": "^1.0.1",
-            "is-regex": "^1.0.4",
-            "object-is": "^1.0.1",
-            "object-keys": "^1.1.1",
-            "regexp.prototype.flags": "^1.2.0"
-          }
-        },
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
-      }
-    },
-    "react-prop-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz",
-      "integrity": "sha1-+ZsL+0AGkpya8gUefBQUpcdbk9A=",
-      "dev": true,
-      "requires": {
-        "warning": "^3.0.0"
-      }
     },
     "react-redux": {
       "version": "7.2.0",
@@ -15481,79 +14324,6 @@
         }
       }
     },
-    "react-router": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.0.1.tgz",
-      "integrity": "sha512-EM7suCPNKb1NxcTZ2LEOWFtQBQRQXecLxVpdsP4DW4PbbqYWeRiLyV/Tt1SdCrvT2jcyXAXmVTmzvSzrPR63Bg==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.3.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
-          "integrity": "sha512-wbg3bpgA/ZqWrZuMOeJi8+SKMhr7X9TesL/rXMjTzh0p0JUBo3II8DHboYbuIXWRlttrUFxwcu/5kygrCw8fJw==",
-          "dev": true,
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        }
-      }
-    },
-    "react-router-dom": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.0.1.tgz",
-      "integrity": "sha512-zaVHSy7NN0G91/Bz9GD4owex5+eop+KvgbxXsP/O+iW1/Ln+BrJ8QiIR5a6xNPtrdTvLkxqlDClx13QO1uB8CA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.0.1",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      }
-    },
-    "react-select": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-2.4.4.tgz",
-      "integrity": "sha512-C4QPLgy9h42J/KkdrpVxNmkY6p4lb49fsrbDk/hRcZpX7JvZPNb6mGj+c5SzyEtBv1DmQ9oPH4NmhAFvCrg8Jw==",
-      "dev": true,
-      "requires": {
-        "classnames": "^2.2.5",
-        "emotion": "^9.1.2",
-        "memoize-one": "^5.0.0",
-        "prop-types": "^15.6.0",
-        "raf": "^3.4.0",
-        "react-input-autosize": "^2.2.1",
-        "react-transition-group": "^2.2.1"
-      },
-      "dependencies": {
-        "react-transition-group": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
-          "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
-          "dev": true,
-          "requires": {
-            "dom-helpers": "^3.4.0",
-            "loose-envify": "^1.4.0",
-            "prop-types": "^15.6.2",
-            "react-lifecycles-compat": "^3.0.4"
-          }
-        }
-      }
-    },
     "react-test-renderer": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.12.0.tgz",
@@ -15576,50 +14346,6 @@
             "object-assign": "^4.1.1"
           }
         }
-      }
-    },
-    "react-transition-group": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.2.1.tgz",
-      "integrity": "sha512-IXrPr93VzCPupwm2O6n6C2kJIofJ/Rp5Ltihhm9UfE8lkuVX2ng/SUUl/oWjblybK9Fq2Io7LGa6maVqPB762Q==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.4.5",
-        "dom-helpers": "^3.4.0",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      }
-    },
-    "react-virtualized-auto-sizer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz",
-      "integrity": "sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg==",
-      "dev": true
-    },
-    "react-window": {
-      "version": "github:mattermost/react-window#4c694b7633a2527a42c4952235719fefa3accb80",
-      "from": "github:mattermost/react-window#4c694b7633a2527a42c4952235719fefa3accb80",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "memoize-one": "^3.1.1"
-      },
-      "dependencies": {
-        "memoize-one": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-3.1.1.tgz",
-          "integrity": "sha512-YqVh744GsMlZu6xkhGslPSqSurOv6P+kLN2J3ysBZfagLcL5FdRK/0UpgLoL8hwjjEvvAVkjJZyFP+1T6p1vgA==",
-          "dev": true
-        }
-      }
-    },
-    "reactcss": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
-      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.0.1"
       }
     },
     "read-pkg": {
@@ -15715,12 +14441,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "rebound": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/rebound/-/rebound-0.1.0.tgz",
-      "integrity": "sha1-BjjGGpNma7UVpYoD4c+zQCHoi3I=",
-      "dev": true
-    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -15744,12 +14464,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redux-action-buffer/-/redux-action-buffer-1.2.0.tgz",
       "integrity": "sha1-LsCh2JnMn29EzN60Me5SrUHdl1U="
-    },
-    "redux-batched-actions": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/redux-batched-actions/-/redux-batched-actions-0.4.1.tgz",
-      "integrity": "sha512-r6tLDyBP3U9cXNLEHs0n1mX5TQfmk6xE0Y9uinYZ5HOyAWDgIJxYqRRkU/bC6XrJ4nS7tasNbxaHJHVmf9UdkA==",
-      "dev": true
     },
     "redux-devtools-core": {
       "version": "0.2.1",
@@ -15781,9 +14495,9 @@
       }
     },
     "redux-persist": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-4.10.2.tgz",
-      "integrity": "sha512-U+e0ieMGC69Zr72929iJW40dEld7Mflh6mu0eJtVMLGfMq/aJqjxUM1hzyUWMR1VUyAEEdPHuQmeq5ti9krIgg==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-4.9.1.tgz",
+      "integrity": "sha512-XoOmfPyo9GEU/WLH9FgB47dNIN9l5ArjHes4o7vUWx9nxZoPxnVodhuHdyc4Ot+fMkdj3L2LTqSHhwrkr0QFUg==",
       "requires": {
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.4",
@@ -16153,12 +14867,6 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true
     },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==",
-      "dev": true
-    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -16429,16 +15137,6 @@
       "resolved": "https://registry.npmjs.org/sc-formatter/-/sc-formatter-3.0.2.tgz",
       "integrity": "sha512-9PbqYBpCq+OoEeRQ3QfFIGE6qwjjBcd2j7UjgDlhnZbtSnuGgHdcRklPKYGuYFH82V/dwd+AIpu8XvA1zqTd+A=="
     },
-    "scheduler": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
     "schema-utils": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
@@ -16576,12 +15274,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shallow-equals/-/shallow-equals-1.0.0.tgz",
       "integrity": "sha1-JLdL8cY0wR7Uxxgqbfb7MA3OQ5A="
-    },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -16810,9 +15502,9 @@
       }
     },
     "socketcluster-client": {
-      "version": "14.3.1",
-      "resolved": "https://registry.npmjs.org/socketcluster-client/-/socketcluster-client-14.3.1.tgz",
-      "integrity": "sha512-Sd/T0K/9UlqTfz+HUuFq90dshA5OBJPQbdkRzGtcKIOm52fkdsBTt0FYpiuzzxv5VrU7PWpRm6KIfNXyPwlLpw==",
+      "version": "14.3.2",
+      "resolved": "https://registry.npmjs.org/socketcluster-client/-/socketcluster-client-14.3.2.tgz",
+      "integrity": "sha512-xDtgW7Ss0ARlfhx53bJ5GY5THDdEOeJnT+/C9Rmrj/vnZr54xeiQfrCZJbcglwe732nK3V+uZq87IvrRl7Hn4g==",
       "requires": {
         "buffer": "^5.2.1",
         "clone": "2.1.1",
@@ -16823,16 +15515,16 @@
         "sc-errors": "^2.0.1",
         "sc-formatter": "^3.0.1",
         "uuid": "3.2.1",
-        "ws": "7.1.0"
+        "ws": "^7.5.0"
       },
       "dependencies": {
         "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
           }
         },
         "uuid": {
@@ -16841,12 +15533,9 @@
           "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
         },
         "ws": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.0.tgz",
-          "integrity": "sha512-Swie2C4fs7CkwlHu1glMePLYJJsWjzhl1vm3ZaLplD0h7OMkZyZ6kLTB/OagiU923bZrPFXuDTeEqaEN4NWG4g==",
-          "requires": {
-            "async-limiter": "^1.0.0"
-          }
+          "version": "7.5.5",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
+          "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w=="
         }
       }
     },
@@ -17515,105 +16204,6 @@
         }
       }
     },
-    "style-value-types": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-3.1.7.tgz",
-      "integrity": "sha512-jPaG5HcAPs3vetSwOJozrBXxuHo9tjZVnbRyBjxqb00c2saIoeuBJc1/2MtvB8eRZy41u/BBDH0CpfzWixftKg==",
-      "dev": true,
-      "requires": {
-        "hey-listen": "^1.0.8",
-        "tslib": "^1.10.0"
-      }
-    },
-    "stylefire": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/stylefire/-/stylefire-4.1.4.tgz",
-      "integrity": "sha512-bp9nNTTFHdIQp/4szBuF2z85rMAq5oySeAHdpNgPTcVlXDrwsi1FjjOLug/4+yx1p8eMFFGrkAex7b5/M95ivg==",
-      "dev": true,
-      "requires": {
-        "@popmotion/popcorn": "^0.4.0",
-        "framesync": "^4.0.0",
-        "hey-listen": "^1.0.8",
-        "style-value-types": "^3.1.4"
-      }
-    },
-    "stylis": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
-      "integrity": "sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==",
-      "dev": true
-    },
-    "stylis-rule-sheet": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
-      "dev": true
-    },
-    "superagent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.1.0.tgz",
-      "integrity": "sha512-7V6JVx5N+eTL1MMqRBX0v0bG04UjrjAvvZJTF/VDH/SH2GjSLqlrcYepFlpTrXpm37aSY6h3GGVWGxXl/98TKA==",
-      "dev": true,
-      "requires": {
-        "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.2",
-        "debug": "^4.1.1",
-        "fast-safe-stringify": "^2.0.6",
-        "form-data": "^2.3.3",
-        "formidable": "^1.2.1",
-        "methods": "^1.1.2",
-        "mime": "^2.4.4",
-        "qs": "^6.7.0",
-        "readable-stream": "^3.4.0",
-        "semver": "^6.1.1"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-          "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.9.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-          "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -17845,24 +16435,6 @@
         "setimmediate": "^1.0.4"
       }
     },
-    "tiny-invariant": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
-      "integrity": "sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==",
-      "dev": true
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
-      "dev": true
-    },
-    "tinycolor2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
-      "dev": true
-    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -17875,25 +16447,10 @@
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
-    "to-camel-case": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-camel-case/-/to-camel-case-1.0.0.tgz",
-      "integrity": "sha1-GlYFSy+daWKYzmamCJcyK29CPkY=",
-      "dev": true,
-      "requires": {
-        "to-space-case": "^1.0.0"
-      }
-    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
-    },
-    "to-no-case": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
-      "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo=",
       "dev": true
     },
     "to-object-path": {
@@ -17936,24 +16493,6 @@
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
-      }
-    },
-    "to-space-case": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
-      "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
-      "dev": true,
-      "requires": {
-        "to-no-case": "^1.0.0"
-      }
-    },
-    "touch": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-2.0.2.tgz",
-      "integrity": "sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==",
-      "dev": true,
-      "requires": {
-        "nopt": "~1.0.10"
       }
     },
     "tough-cookie": {
@@ -18060,12 +16599,6 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
-    "typed-styles": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
-      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==",
-      "dev": true
-    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -18085,21 +16618,6 @@
       "version": "3.9.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
       "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw=="
-    },
-    "ua-parser-js": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==",
-      "dev": true
-    },
-    "uncontrollable": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-5.1.0.tgz",
-      "integrity": "sha512-5FXYaFANKaafg4IVZXUNtGyzsnYEvqlr9wQ3WpZxFpEUxl29A3H6Q4G1Dnnorvq9TGOGATBApWR4YpLAh+F5hw==",
-      "dev": true,
-      "requires": {
-        "invariant": "^2.2.4"
-      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -18317,12 +16835,6 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==",
-      "dev": true
-    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -18365,15 +16877,6 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.x"
-      }
-    },
-    "warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {
@@ -18843,9 +17346,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
@@ -18936,28 +17439,6 @@
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
-      }
-    },
-    "worker-loader": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-1.1.1.tgz",
-      "integrity": "sha512-qJZLVS/jMCBITDzPo/RuweYSIG8VJP5P67mP/71alGyTZRe1LYJFdwLjLalY3T5ifx0bMDRD3OB6P2p1escvlg==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.0.0",
-        "schema-utils": "^0.4.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "0.4.7",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        }
       }
     },
     "wrap-ansi": {
@@ -19214,12 +17695,6 @@
           "dev": true
         }
       }
-    },
-    "zen-observable": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.14.tgz",
-      "integrity": "sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g==",
-      "dev": true
     }
   }
 }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -55,7 +55,6 @@
     "jest": "26.1.0",
     "jest-canvas-mock": "2.2.0",
     "jest-junit": "11.0.1",
-    "mattermost-webapp": "github:mattermost/mattermost-webapp#23f5f93d9f12a7e2b5623e5cee6814366abd9a0f",
     "node-sass": "4.14.1",
     "sass-loader": "9.0.2",
     "style-loader": "1.2.1",

--- a/webapp/src/constants.ts
+++ b/webapp/src/constants.ts
@@ -1,0 +1,2 @@
+export const customPropName = 'customtable';
+export const customURLAction = 'table_cell_click';

--- a/webapp/src/hooks.tsx
+++ b/webapp/src/hooks.tsx
@@ -29,8 +29,8 @@ export default class Hooks {
             props: {
                 [customPropName]: JSON.stringify({
                     '0 0': `/echo I'm a Rocket!`,
-                    '0 1': `/echo I'm a Smile!`,
-                    '0 2': `/echo I'm a Thumbs Up!`,
+                    '1 0': `/echo I'm a Smile!`,
+                    '2 0': `/echo I'm a Thumbs Up!`,
                 }),
             } as any,
         } as Post;
@@ -68,10 +68,10 @@ export default class Hooks {
         const [header, spacing, ...rows] = message.split('\n');
 
         for (const coord of Object.keys(tableData)) {
-            const [xStr, yStr] = coord.split(' ');
+            const [yStr, xStr] = coord.split(' ');
 
-            const x = parseInt(xStr);
             const y = parseInt(yStr);
+            const x = parseInt(xStr);
 
             const columns = rows[y].split('|');
             const cellText = columns[x + 1];

--- a/webapp/src/hooks.tsx
+++ b/webapp/src/hooks.tsx
@@ -1,0 +1,90 @@
+import {ContextArgs, SlashCommandWillBePostedResponse, Store} from './types/plugin_registry';
+import {Post} from 'mattermost-redux/types/posts';
+
+import {customPropName, customURLAction} from './constants'
+import {Client4} from 'mattermost-redux/client';
+
+export type SlashCommandTableData = {
+    [xyCoord: string]: string;
+}
+
+export default class Hooks {
+    constructor(private store: Store) {}
+
+    slashCommandWillBePostedHook = async (message: string, contextArgs: ContextArgs): SlashCommandWillBePostedResponse => {
+        const slashPrefix = '/make-table';
+
+        if (!message.startsWith(slashPrefix)) {
+            return {message, args: contextArgs};
+        }
+
+        const post = {
+            message: `| Left-Aligned  | Center Aligned  | Right Aligned |
+            | :------------ |:---------------:| -----:|
+            | :rocket: | this text       |  $100 |
+            | :smile: | is              |   $10 |
+            | :+1: | centered        |    $1 |`,
+            channel_id: contextArgs.channel_id,
+            root_id: contextArgs.root_id,
+            props: {
+                [customPropName]: JSON.stringify({
+                    '0 0': `/echo I'm a Rocket!`,
+                    '0 1': `/echo I'm a Smile!`,
+                    '0 2': `/echo I'm a Thumbs Up!`,
+                }),
+            } as any,
+        } as Post;
+
+        Client4.createPost(post);
+
+        return {};
+    }
+
+    /**
+        * Register a hook that will be called before a message is formatted into Markdown.
+        * Accepts a function that receives the unmodified post and the message (potentially
+        * already modified by other hooks) as arguments. This function must return a string
+        * message that will be formatted.
+        * Returns a unique identifier.
+    */
+    messageWillFormatHook = (post: Post, message: string): string => {
+        if (!post.props?.[customPropName]) {
+            return message;
+        }
+
+        const tableDataProp: string = post.props[customPropName];
+
+        try {
+            return this.renderTableWithLinks(tableDataProp, post, message)
+        } catch (e) {
+            console.error('Error formatting custom table', e)
+            return message;
+        }
+
+    }
+
+    renderTableWithLinks = (tableDataProp: string, post: Post, message: string): string => {
+        const tableData = JSON.parse(tableDataProp);
+        const [header, spacing, ...rows] = message.split('\n');
+
+        for (const coord of Object.keys(tableData)) {
+            const [xStr, yStr] = coord.split(' ');
+
+            const x = parseInt(xStr);
+            const y = parseInt(yStr);
+
+            const columns = rows[y].split('|');
+            const cellText = columns[x + 1];
+
+            const cellURL = `${customPropName}://${customURLAction}?postID=${post.id}&x=${x}&y=${y}`;
+            const link = `[${cellText}](${cellURL})`;
+
+            columns[x + 1] = link;
+
+            rows[y] = columns.join('|')
+        }
+
+        const rowsStr = rows.join('\n');
+        return [header, spacing, rowsStr].join('\n');
+    }
+}

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -2,16 +2,96 @@ import {Store, Action} from 'redux';
 
 import {GlobalState} from 'mattermost-redux/types/store';
 
+import {getPost} from 'mattermost-redux/selectors/entities/posts';
+import {getChannel} from 'mattermost-redux/selectors/entities/channels';
+import {Client4} from 'mattermost-redux/client';
+import {Registry} from 'types/plugin_registry';
+
 import manifest from './manifest';
 
-// eslint-disable-next-line import/no-unresolved
-import {PluginRegistry} from './types/mattermost-webapp';
+import Hooks, {SlashCommandTableData} from './hooks';
+import {customPropName, customURLAction} from './constants'
+import {parseQueryString} from './utils';
+
+type CommandArgs = {
+    channel_id: string;
+    team_id?: string;
+    root_id?: string;
+}
 
 export default class Plugin {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
-    public async initialize(registry: PluginRegistry, store: Store<GlobalState, Action<Record<string, unknown>>>) {
+    registry!: Registry;
+    store!: Store<GlobalState, Action<Record<string, unknown>>>;
+
+    public async initialize(registry: Registry, store: Store<GlobalState, Action<Record<string, unknown>>>) {
         // @see https://developers.mattermost.com/extend/plugins/webapp/reference/
+
+        this.registry = registry;
+        this.store = store;
+
+        const hooks = new Hooks(store);
+        registry.registerMessageWillFormatHook(hooks.messageWillFormatHook);
+        registry.registerSlashCommandWillBePostedHook(hooks.slashCommandWillBePostedHook);
+
+        window.addEventListener('click', this.anchorClickHandler);
     }
+
+    uninitialize() {
+        window.removeEventListener('click', this.anchorClickHandler);
+    }
+
+    anchorClickHandler = (e: MouseEvent) => {
+        const href = getHref(e.target as HTMLElement, 5);
+        if (!href) {
+            return;
+        }
+
+        const prefix = `${customPropName}://`;
+        if (!href.startsWith(prefix)) {
+            return;
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+
+        const link = href.substring(prefix.length);
+        const [name, query] = link.split('?');
+
+        if (name === customURLAction) {
+            const {postID, x, y} = parseQueryString(query);
+            const post = getPost(this.store.getState(), postID);
+            const channel = getChannel(this.store.getState(), post.channel_id);
+
+            const tableDataProp: string = post.props[customPropName];
+            const tableData: SlashCommandTableData = JSON.parse(tableDataProp);
+
+            const coord = `${x} ${y}`;
+            const slashCommand = tableData[coord];
+
+            (Client4.executeCommand as unknown as (command: string, commandArgs: CommandArgs) => void)(slashCommand, {
+                channel_id: post.channel_id,
+                team_id: channel.team_id,
+                root_id: post.root_id || post.id,
+            });
+        }
+    }
+}
+
+const getHref = (target: HTMLElement, limit: number) => {
+    let element: HTMLElement = target;
+    for (let i=0; i < limit; i++) {
+        const anchor = element as HTMLAnchorElement;
+        if (anchor.href) {
+            return anchor.href;
+        }
+
+        if (!element.parentElement) {
+            return '';
+        }
+        element = element.parentElement;
+    }
+
+    return '';
 }
 
 declare global {

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -65,7 +65,7 @@ export default class Plugin {
             const tableDataProp: string = post.props[customPropName];
             const tableData: SlashCommandTableData = JSON.parse(tableDataProp);
 
-            const coord = `${x} ${y}`;
+            const coord = `${y} ${x}`;
             const slashCommand = tableData[coord];
 
             (Client4.executeCommand as unknown as (command: string, commandArgs: CommandArgs) => void)(slashCommand, {

--- a/webapp/src/types/mattermost-webapp/index.d.ts
+++ b/webapp/src/types/mattermost-webapp/index.d.ts
@@ -1,5 +1,0 @@
-export interface PluginRegistry {
-    registerPostTypeComponent(typeName: string, component: React.ElementType)
-
-    // Add more if needed from https://developers.mattermost.com/extend/plugins/webapp/reference
-}

--- a/webapp/src/types/plugin_registry.ts
+++ b/webapp/src/types/plugin_registry.ts
@@ -1,0 +1,9 @@
+import {Post} from 'mattermost-redux/types/posts';
+
+export type ContextArgs = {channel_id: string, root_id?: string};
+export type SlashCommandWillBePostedResponse = Promise<{} | {message: string, args: ContextArgs}>;
+
+export interface Registry {
+    registerMessageWillFormatHook: (hook: (post: Post, message: string) => string) => void;
+    registerSlashCommandWillBePostedHook: (callback: (message: string, contextArgs: ContextArgs) => SlashCommandWillBePostedResponse) => string;
+}

--- a/webapp/src/utils.ts
+++ b/webapp/src/utils.ts
@@ -1,0 +1,12 @@
+export function parseQueryString(query: string): any {
+    const vars = query.split('&');
+    return vars.reduce((accum, v) => {
+        const pair = v.split('=');
+        const key = decodeURIComponent(pair[0]);
+        const value = decodeURIComponent(pair[1]);
+        return {
+            ...accum,
+            [key]: value,
+        }
+    }, {});
+}


### PR DESCRIPTION
This example shows how to inject slash commands into posts as hyperlinks.

-----

How to use this in your integration:

With this plugin (or a fork) installed, create a post like the one shown in the code block below. Your post can have any table, and any slash commands. Feel free to change the code to use a different identifier than `customtable`.

-----

To run the example:
- Run the command `/make-table`. A post will be made with a markdown table.
- Click an emoji in the table
- A slash command will be run, creating a post based on the emoji that was clicked

-----

How this works:

Here's the post created by `/make-table`

```ts
const post = {
    message: `| Left-Aligned  | Center Aligned  | Right Aligned |
    | :------------ |:---------------:| -----:|
    | :rocket:  | this text       |  $100 |
    | :smile:   | is              |   $10 |
    | :+1:      | centered        |    $1 |`,
    channel_id: contextArgs.channel_id,
    root_id: contextArgs.root_id,
    props: {
        'customtable': JSON.stringify({
            '0 0': `/echo I'm a Rocket!`,
            '1 0': `/echo I'm a Smile!`,
            '2 0': `/echo I'm a Thumbs Up!`,
        }),
    },
};
```

In the `post.props` field, there is a key `customtable`, with the value of a JSON object. This object's keys are stringified coordinates as `"y x"`. The values are slash commands to be run when that table cell is clicked.

The plugin [edits the markdown](https://github.com/mickmister/mattermost-plugin-link-actions-example/blob/753bcde77186dbb0be353c3b6f0fd18f56be9580/webapp/src/hooks.tsx#L50) just before render, using [registerMessageWillFormatHook](https://developers.mattermost.com/integrate/plugins/webapp/reference/#registerMessageWillFormatHook), adding hyperlinks using data from the post's props.

The plugin also registers a global click listener, which handles the click of each hyperlink. If the link matches the format the plugin is expecting, we process the click and stop the click event's propagation. Ideally there is instead a method added to the webapp plugin registry to handle link clicks instead, to remove this need for the global click listener.